### PR TITLE
Remove personal iOS key

### DIFF
--- a/A11YTools/A11YTools.iOS/A11YTools.iOS.csproj
+++ b/A11YTools/A11YTools.iOS/A11YTools.iOS.csproj
@@ -46,7 +46,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <MtouchArch>ARM64</MtouchArch>
-    <CodesignKey>Apple Development: Shane NEuville %288692K2PTQ6%29</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>None</MtouchLink>


### PR DESCRIPTION
causes build errors for others who don't have the same key