### PR TITLE
Fixes android set focus

### DIFF
--- a/A11YTools/A11YTools.Android/AndroidA11yService.cs
+++ b/A11YTools/A11YTools.Android/AndroidA11yService.cs
@@ -12,7 +12,6 @@ namespace A11YTools.Droid
     {
         public void SetControlType(VisualElement element, ControlType controlType)
         {
-            var renderer = Platform.GetRenderer(element);
             var view = element.GetViewForAccessibility();
 
             if (view == null)
@@ -62,10 +61,8 @@ namespace A11YTools.Droid
 
         public void SetFocus(VisualElement element)
         {
-            var renderer = Platform.GetRenderer(element);
             var view = element.GetViewForAccessibility();
-
-            view?.SendAccessibilityEvent(EventTypes.ViewAccessibilityFocused);
+            view?.SendAccessibilityEvent((EventTypes)(int)WindowsChange.AccessibilityFocused);
         }
     }
 }


### PR DESCRIPTION
Original code used to read out the elements name/ help text but not move the screenreaders focus.
This PR fixes that by moving the screenreaders' focus.

The solution was found here - https://forums.xamarin.com/discussion/178244/android-change-accessibility-focus